### PR TITLE
fix(helm): Move `ttlSecondsAfterFinished` to correct spec level in CronJob

### DIFF
--- a/deploy/charts/ghes-schedule-scanner/templates/cronjob.yaml
+++ b/deploy/charts/ghes-schedule-scanner/templates/cronjob.yaml
@@ -13,9 +13,9 @@ spec:
   timeZone: {{ .Values.timeZone | default "Etc/UTC" }}
   successfulJobsHistoryLimit: {{ .Values.successfulJobsHistoryLimit }}
   failedJobsHistoryLimit: {{ .Values.failedJobsHistoryLimit }}
-  ttlSecondsAfterFinished: {{ .Values.ttlSecondsAfterFinished }}
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: {{ .Values.ttlSecondsAfterFinished }}
       template:
         metadata:
           {{- with .Values.podAnnotations }}


### PR DESCRIPTION
<!--
Thank you for contributing to ghes-schedule-scanner! 

Please make sure that your PR meets the following requirements:
-->

#### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind enhancement
/kind test
-->

/kind helm

#### What this PR does / why we need it:

- `ttlSecondsAfterFinished` should be defined at Job spec level instead of CronJob spec level according to k8s API spec.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Optional: Add any notes for your reviewers here.
-->

#### Additional documentation:
<!--
Include additional documentation e.g. usage docs, etc.
-->

#### Testing done:
<!--
Include details of the testing you've done.
For example:
- Unit tests added/modified
- Integration tests added/modified
- Manual verification done
-->
